### PR TITLE
Fix error handling when fail to get auth token

### DIFF
--- a/src/api/api-client.ts
+++ b/src/api/api-client.ts
@@ -58,7 +58,8 @@ class ApiClient {
             await this.client.put(`https://graph.microsoft.com/beta/trustFramework/policies/${policyId}/$value`, content);
         }
         catch (err) {
-            throw new Error(JSON.stringify(err.response.data.error.message, null, 3));
+            const message = err.response ? JSON.stringify(err.response.data, null, 3) : err.message;
+            throw new Error(message);
         }
     }
 }


### PR DESCRIPTION
When the `ApiClient` tries to upload policies and fails to get the Bearer auth token, the thrown error won't have `response` because the actual request for uploading the policy hasn't been sent. The original logic will cause an error when accessing `err.response.data`.
Fix the error handling so that when there's no response, use the original error message as the wrapped error message.