### PR TITLE
Fix publish issues

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ jobs:
           node-version: '12.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
+      - run: npm run build
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ieftool",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Uploader tool for B2C",
   "main": "dist/entry.js",
   "license": "MIT",


### PR DESCRIPTION
Pipeline didn't run compile the src to raw js, and when published to npm were missing the files in dist. The package.json points to ``dist/entry.js`` as its entry point, but since that was missing you would get a command not found error